### PR TITLE
Fixed top-cited example for mononymic groups and encoding

### DIFF
--- a/examples/top-cited-astronomers.py
+++ b/examples/top-cited-astronomers.py
@@ -28,8 +28,13 @@ for astronomer in total_citations.keys():
         duplicate_astronomers.append(astronomer)
         continue
 
-    last_name, first_name = astronomer.split(", ")[:2]
-    short_name = "{0}, {1}.".format(last_name.encode("utf-8"), first_name[0])
+    try:
+        last_name, first_name = astronomer.split(", ")[:2]
+        short_name = "{0}, {1}.".format(last_name.encode("utf-8"), first_name[0])
+    # What if Cher (or another mononym) writes an astronomy paper?
+    except ValueError:
+        last_name = astronomer.split(", ")[0]
+        short_name = "{0}".format(last_name.encode("utf-8"))
 
     # Is this a short name?
     if astronomer == short_name: continue
@@ -44,11 +49,11 @@ for astronomer in total_citations.keys():
 # Delete the duplicates
 for duplicate_astronomer in set(duplicate_astronomers):
     del total_citations[duplicate_astronomer]
-print("After duplicates, we have the top {0} cited astronomers!".format(len(total_citations)))
+print("\nAfter duplicates, we have the top {0} cited astronomers!".format(len(total_citations)))
 
 # Let's sort them and just get the top 100
 most_successful_astronomers = sorted(total_citations, key=total_citations.get, reverse=True)[:100]
 
 # Voila!
 for i, astronomer in enumerate(most_successful_astronomers, 1):
-    print("{0}. {1} with {2} total citations".format(i, astronomer, total_citations[astronomer]))
+    print("{0}. {1} with {2} total citations".format(i, astronomer.encode("utf-8"), total_citations[astronomer]))


### PR DESCRIPTION
Example was breaking on authors with no ```first_name``` in author string, such as "Particle Data Group". 

Encoding also needed to be passed to the final printout to screen, which had a ```UnicodeEncodeError``` for authors like "Sjöstrand, Torbjörn". 