### PR TITLE
Support Python 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ branches:
 language: python
 python:
   - 2.7
+  - 3.4
 virtualenv:
   system_site_packages: true
 install: 

--- a/ads/__init__.py
+++ b/ads/__init__.py
@@ -6,9 +6,9 @@
 __author__ = "Andy Casey <andy@astrowizici.st>"
 __version__ = "0.0.809"
 
-import network
-from core import query, metrics, metadata, retrieve_article
+from . import network
+from .core import query, metrics, metadata, retrieve_article
 
 # ads.core.search will be deprecated in future
 # You should use ads.core.query instead
-from core import search
+from .core import search

--- a/ads/core.py
+++ b/ads/core.py
@@ -9,11 +9,12 @@ import os
 import warnings
 
 # Third party
+import six
 import requests
 import requests_futures.sessions
 
 # Module specific
-import parser, utils
+from . import parser, utils
 
 API_MAX_ROWS = 200
 DEV_KEY = utils.get_dev_key()
@@ -43,7 +44,7 @@ class Article(object):
 
         # Update this object to have attributes for everything in attribute
         # dictionary.
-        for key, value in kwargs.iteritems():
+        for key, value in six.iteritems(kwargs):
             setattr(self, key, value)
 
         if "bibcode" in kwargs:
@@ -73,7 +74,7 @@ class Article(object):
         return self._raw.items()
 
     def iteritems(self):
-        return self._raw.iteritems()
+        return six.iteritems(self._raw)
 
     @property
     def bibtex(self):
@@ -115,7 +116,7 @@ class Article(object):
         }
         parsers = {
             "author":           lambda article: _(" and \n".join([" and ".join(["{{{0}}}, {1}".format(author.split(",")[0], "~".join(["{0}.".format(name[0]) \
-                                    for name in author.split(",")[1].split()])) for author in article.author[i:i+4]]) for i in xrange(0, len(article.author), 4)])),
+                                    for name in author.split(",")[1].split()])) for author in article.author[i:i+4]]) for i in range(0, len(article.author), 4)])),
             "month":            lambda article: months[int(article.pubdate.split("-")[1])],
             "pages":            lambda article: _(article.page[0]),
             "title":            lambda article: "{{{{{0}}}}}".format(article.title[0]),
@@ -238,7 +239,7 @@ class Article(object):
         total_articles = len(level) - 1
         kwargs.setdefault("rows", "all")
 
-        for level_num in xrange(depth):
+        for level_num in range(depth):
 
             level_requests = [search("references(bibcode:{bibcode})".format(
                 bibcode=article.bibcode), **kwargs) for article in level]
@@ -288,7 +289,7 @@ class Article(object):
         total_articles = len(level) - 1
         kwargs.setdefault("rows", "all")
 
-        for level_num in xrange(depth):
+        for level_num in range(depth):
 
             level_requests = [search("citations(bibcode:{bibcode})".format(
                 bibcode=article.bibcode), **kwargs) for article in level]
@@ -360,7 +361,7 @@ class query(object):
                 if not rows % API_MAX_ROWS: num_additional_queries -= 1
 
             # Initiate future requests
-            for i in xrange(1, num_additional_queries + 1):
+            for i in range(1, num_additional_queries + 1):
                 # Update payload to start at new point
                 self.payload["start"] = i * API_MAX_ROWS
 
@@ -375,6 +376,9 @@ class query(object):
         return self
 
     def next(self):
+        return self.__next__()
+
+    def __next__(self):
 
         if len(self.active_requests) == 0 and len(self.retrieved_articles) == 0:
             self.session.executor.shutdown()

--- a/ads/network.py
+++ b/ads/network.py
@@ -12,8 +12,8 @@ import json
 import os
 
 # Module specific
-from core import search
-from utils import unique_preserved_list
+from .core import search
+from .utils import unique_preserved_list
 
 __all__ = ["nodes", "export", "coauthors"]
 
@@ -49,7 +49,7 @@ def coauthors(name, depth=1, author_repr=None):
 
     all_articles = []
     level_authors = [name]
-    for i in xrange(depth):
+    for i in range(depth):
 
         next_level_authors = []
         for j, author in enumerate(level_authors):

--- a/ads/parser.py
+++ b/ads/parser.py
@@ -10,6 +10,8 @@ __author__ = "Andy Casey <andy@astrowizici.st>"
 import datetime
 import time
 
+import six
+
 __all__ = ["rows", "ordering", "dates", "start"]
 
 def query(query, title, author):
@@ -132,7 +134,7 @@ def affiliation(affiliation=None, pos=None):
                     "list-type of up to two integers")
 
             try:
-                pos = map(int, pos)
+                pos = list(map(int, pos))
             except (TypeError, ValueError):
                 raise TypeError("affiliation position must be an integer or "\
                     "list-type of up to two integers")
@@ -319,7 +321,7 @@ def dates(input_dates):
         start_date = _date(start_date, default_month=1)
         end_date = _date(end_date, default_month=12)
 
-    elif isinstance(input_dates, (str, unicode)):
+    elif isinstance(input_dates, (str, six.text_type)):
 
         # We will accept "2002-", "2002..", "..2003", "2002..2003"
         # "2002/01..2002/08", "2002/04..", "2002/07", "2002-7", "2002-07

--- a/ads/tests/test_parsers.py
+++ b/ads/tests/test_parsers.py
@@ -4,6 +4,7 @@
 
 __author__ = "Andy Casey <andy@astrowizici.st>"
 
+import six
 import unittest
 import ads.parser as parse
 
@@ -113,7 +114,7 @@ class TestOrderingParser(unittest.TestCase):
             "popularity": "popularity",
             "relevance": "relevance"
         }
-        for sort_input, sort_option in sort_options.iteritems():
+        for sort_input, sort_option in six.iteritems(sort_options):
             for order_option in order_options:        
                 assert (sort_option.lower(), order_option.lower()) == parse.ordering(sort_input, order_option)
                 assert (sort_option.lower(), order_option.lower()) == parse.ordering(sort_input, order_option.upper())

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
+six
 requests
 requests_futures

--- a/setup.py
+++ b/setup.py
@@ -39,6 +39,7 @@ setup(name="ads",
       description="A Python module for NASA's ADS that doesn't suck.",
       long_description=readfile(os.path.join(os.path.dirname(__file__), "README.md")),
       install_requires=[
+        "six",
         "requests",
         "requests_futures"
       ]


### PR DESCRIPTION
It would be great if `ads` supported Python 3!

This PR contains the changes needed for the unit tests to pass under both 2.7 and 3.4 on my machine.  (But I must warn that I am not an expert on Python 3 porting.)