### PR TITLE
Python 3 bug: allow more than one query

### DIFF
--- a/ads/config.py
+++ b/ads/config.py
@@ -11,11 +11,11 @@ METRICS_URL = '{}/metrics/'.format(ADSWS_API_URL)
 EXPORT_URL = '{}/export/'.format(ADSWS_API_URL)
 
 # Token discovery variables
-TOKEN_FILES = map(os.path.expanduser,
+TOKEN_FILES = list(map(os.path.expanduser,
     [
         "~/.ads/token",
         "~/.ads/dev_key",
     ]
-)
+))
 TOKEN_ENVIRON_VARS = ["ADS_API_TOKEN", "ADS_DEV_KEY"]
 token = None  # for setting in-situ


### PR DESCRIPTION
I noticed that the new version obtains the token by reading the `TOKEN_FILES` whenever a new `BaseQuery` instance is created.  However, `config.py` defines `TOKEN_FILES` as a `map` rather than a `list`.  This does not work in Python 3 because `map` now returns an iterator object that can only be iterated over once.  As a result, only the first query succeeds, and the token cannot be found from the second query onward.

The attached PR fixes this.