### PR TITLE
Article: _get_field returns None when no data are returned; closes #26

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,12 +93,12 @@ first_paper.bibtex                first_paper.first_author          first_paper.
 
 Which allows you to easily build complicated queries. Feel free to fork this repository and add your own examples!
 
-**Contributors**
+**Authors**
 
-Vladimir Sudilovsky, Dan Foreman-Mackey, Miguel de Val-Borro
+Vladimir Sudilovsky & Andy Casey, Geert Barentsen, Dan Foreman-Mackey, Miguel de Val-Borro
 
 **License**
 
-Copyright 2014 Andy Casey and contributors
+Copyright 2014 the authors 
 
 This is open source software available under the MIT License. For details see the LICENSE file.

--- a/ads/__init__.py
+++ b/ads/__init__.py
@@ -4,7 +4,7 @@
 """ A Python tool for interacting with NASA's ADS """
 
 __author__ = "Andy Casey <andy@astrowizici.st>"
-__version__ = "0.0.809"
+__version__ = "0.11"
 
 from .metrics import MetricsQuery
 from .export import ExportQuery

--- a/ads/search.py
+++ b/ads/search.py
@@ -117,8 +117,12 @@ class Article(object):
         """
         if not hasattr(self, "id") or self.id is None:
             raise APIResponseError("Cannot query an article without an id")
-        sq = SearchQuery(q="id:{}".format(self.id), fl=field)
-        value = next(sq).__getattribute__(field)
+        sq = next(SearchQuery(q="id:{}".format(self.id), fl=field))
+        # If the requested field is not present in the returning Solr doc,
+        # return None instead of hitting _get_field again.
+        if field not in sq._raw:
+            return None
+        value = sq.__getattribute__(field)
         self._raw[field] = value
         return value
 

--- a/ads/tests/stubdata/solr.py
+++ b/ads/tests/stubdata/solr.py
@@ -54,7 +54,6 @@ example_solr_response = r'''{
         "title":["Cyclic Adenosine 3',5'-Monophosphate during Glucose Repression in the Rat Liver"],
         "property":["REFEREED",
           "ARTICLE"],
-        "issue":"4005",
         "email":["-",
           "-",
           "-",

--- a/ads/tests/test_search.py
+++ b/ads/tests/test_search.py
@@ -109,6 +109,7 @@ class TestArticle(unittest.TestCase):
         with MockSolrResponse(SEARCH_URL):
             self.assertEqual(self.article.pubdate, '1971-10-00')
             self.assertEqual(self.article.read_count, 0.0)
+            self.assertIsNone(self.article.issue)
 
 
 class TestSearchQuery(unittest.TestCase):


### PR DESCRIPTION
This patch sets inaccessible article attributes to None when queried.

References #26 