### PR TITLE
Feature/ratelimit singleton

### DIFF
--- a/ads/__init__.py
+++ b/ads/__init__.py
@@ -9,4 +9,5 @@ __version__ = "0.11.3"
 from .metrics import MetricsQuery
 from .export import ExportQuery
 from .search import SearchQuery, query
+from .base import RateLimits
 #from .libraries import LibraryQuery, Library #soon

--- a/ads/tests/mocks.py
+++ b/ads/tests/mocks.py
@@ -31,6 +31,15 @@ class MockApiResponse(HTTPrettyMock):
     """
     context manager than mocks an static adsws-api response
     """
+    limit = 400
+    remaining = 398
+    reset = 1436313600
+
+    @property
+    def remains(self):
+        MockApiResponse.remaining -= 1
+        return MockApiResponse.remaining
+
     def __init__(self, api_endpoint):
         self.api_endpoint = api_endpoint
 
@@ -40,11 +49,13 @@ class MockApiResponse(HTTPrettyMock):
             body='''{"status": "online", "app": "adsws.api"}''',
             content_type="application/json",
             adding_headers={
-                'X-RateLimit-Limit': 400,
-                'X-RateLimit-Remaining': 397,
-                'X-RateLimit-Reset': 1436313600
+                'X-RateLimit-Limit': MockApiResponse.limit,
+                'X-RateLimit-Remaining': self.remains,
+                'X-RateLimit-Reset': MockApiResponse.reset
             }
         )
+
+
 
 
 class MockSolrResponse(HTTPrettyMock):

--- a/ads/tests/test_base.py
+++ b/ads/tests/test_base.py
@@ -2,6 +2,7 @@
 Test that classes for representing the adsws-api specific data structures
 defined in core.py
 """
+import json
 import unittest
 import requests
 import os
@@ -9,7 +10,7 @@ from tempfile import NamedTemporaryFile
 
 import ads.base
 import ads.config
-from ads.base import BaseQuery, APIResponse, RateLimits, Singleton
+from ads.base import BaseQuery, APIResponse, RateLimits, _Singleton
 from .mocks import MockApiResponse
 
 
@@ -107,7 +108,7 @@ class TestRateLimits(unittest.TestCase):
                 pass
 
         self.FakeResponse = FakeResponse
-        Singleton._instances = {}
+        _Singleton._instances = {}
 
         MockApiResponse.remaining = 398
 
@@ -178,9 +179,12 @@ class TestRateLimits(unittest.TestCase):
             self.FakeResponse.load_http_response(
                 requests.get('http://api.unittest')
             )
+
+        message = RateLimits.get_info()
+        self.assertIn('FakeQuery', message)
         self.assertEqual(
-            'FakeQuery: {"reset": "1436313600", "limit": "400", "remaining": "397"}',
-            RateLimits.get_info()
+            {"reset": "1436313600", "limit": "400", "remaining": "397"},
+            json.loads(message.split('FakeQuery: ')[1])
         )
 
 


### PR DESCRIPTION
As per suggested in #47 by @vsudilov and @andycasey.

Basic usage
```python
>>> import ads
>>> from ads.base import RateLimits
>>> q = ads.SearchQuery(q='star', fl=['bibcode'], rows=1)
>>> bibs = [p.bibcode for p in q]
>>> q.response.get_ratelimits()
{'reset': '1462233600', 'limit': '5000', 'remaining': '4901'}
>>> RateLimits('SearchQuery').to_dict()
{'reset': '1462233600', 'limit': '5000', 'remaining': '4901'}
>>> RateLimits.get_info()
'SearchQuery: {"reset": "1462233600", "limit": "5000", "remaining": "4901"}'
```

With metrics query
```python
>>> m = ads.MetricsQuery(bibcodes=bibs)
>>> m.execute()
>>> m.response.get_ratelimits()
{'reset': '1462233600', 'limit': '1000', 'remaining': '997'}
>>> RateLimits('MetricsQuery').to_dict()
{'reset': '1462233600', 'limit': '1000', 'remaining': '997'}
>>> RateLimits.get_info()
'SearchQuery: {"reset": "1462233600", "limit": "5000", "remaining": "4901"}
MetricsQuery: {"reset": "1462233600", "limit": "1000", "remaining": "997"}'
```

.... and exports query
```python
>>> e = ads.ExportQuery(bibcodes=bibs, format='bibtex')                                                                                          
>>> e.execute()
>>> RateLimits('ExportQuery').to_dict()
{'reset': '1462233600', 'limit': '100', 'remaining': '99'}
>>> RateLimits.get_info()
'SearchQuery: {"reset": "1462233600", "limit": "5000", "remaining": "4901"}
MetricsQuery: {"reset": "1462233600", "limit": "1000", "remaining": "997"}
ExportQuery: {"reset": "1462233600", "limit": "100", "remaining": "99"}'
```

Check it behaves like a singleton
```python
>>> RateLimits._instances
{'SearchQuery': <ads.base.RateLimits object at 0x7f28428d9190>, 'MetricsQuery': <ads.base.RateLimits object at 0x7f28428eb050>, 'ExportQuery': <ads.base.RateLimits object at 0x7f28428ebc50>}
>>> rq = RateLimits('SearchQuery')
>>> RateLimits._instances
{'SearchQuery': <ads.base.RateLimits object at 0x7f28428d9190>, 'MetricsQuery': <ads.base.RateLimits object at 0x7f28428eb050>, 'ExportQuery': <ads.base.RateLimits object at 0x7f28428ebc50>}
```

Check any instances have upto date rates
```python
>>> rq.to_dict()
{'reset': '1462233600', 'limit': '5000', 'remaining': '4901'}
>>> q.execute()
>>> rq.to_dict()
{'reset': '1462233600', 'limit': '5000', 'remaining': '4900'}
>>> print rq
SearchQuery: {"reset": "1462233600", "limit": "5000", "remaining": "4900"}
>>> RateLimits.get_info()
'SearchQuery: {"reset": "1462233600", "limit": "5000", "remaining": "4900"}
MetricsQuery: {"reset": "1462233600", "limit": "1000", "remaining": "997"}
ExportQuery: {"reset": "1462233600", "limit": "100", "remaining": "99"}'
```