### PR TITLE
Feature/Sandbox environment for testing

### DIFF
--- a/ads/sandbox.py
+++ b/ads/sandbox.py
@@ -1,0 +1,58 @@
+"""
+Sandbox environment that wraps relevant classes so that they receive mock
+responses rather than contact the live API
+"""
+
+import re
+
+from ads import search
+from .search import SearchQuery as _SearchQuery, Article as _Article
+from .metrics import MetricsQuery as _MetricsQuery
+from .export import ExportQuery as _ExportQuery
+
+from .tests.mocks import MockSolrResponse, MockMetricsResponse, \
+    MockExportResponse
+
+
+class Article(_Article):
+    """
+    Wrapper for ads.search.Article
+    """
+    def _get_field(self, field):
+        with MockSolrResponse(_SearchQuery.HTTP_ENDPOINT):
+            return super(Article, self)._get_field(field)
+
+
+class SearchQuery(_SearchQuery):
+    """
+    Wrapper for ads.SearchQuery
+    """
+    def execute(self):
+        with MockSolrResponse(SearchQuery.HTTP_ENDPOINT):
+            super(SearchQuery, self).execute()
+
+
+class MetricsQuery(_MetricsQuery):
+    """
+    Wrapper for ads.SearchQuery
+    """
+
+    def execute(self):
+        with MockMetricsResponse(MetricsQuery.HTTP_ENDPOINT):
+            return super(MetricsQuery, self).execute()
+
+
+class ExportQuery(_ExportQuery):
+    """
+    Wrapper for ads.SearchQuery
+    """
+
+    def execute(self):
+        with MockExportResponse(re.compile(ExportQuery.HTTP_ENDPOINT)):
+            return super(ExportQuery, self).execute()
+
+
+# Monkey patch relevant classes that are called in ads.search
+search.Article = Article
+search.MetricsQuery = MetricsQuery
+search.ExportQuery = ExportQuery

--- a/ads/tests/test_sandbox.py
+++ b/ads/tests/test_sandbox.py
@@ -1,0 +1,72 @@
+"""
+Tests for the search interface
+"""
+import json
+import unittest
+
+from ads.sandbox import SearchQuery, MetricsQuery, ExportQuery
+
+from .stubdata.metrics import example_metrics_response
+from .stubdata.solr import example_solr_response
+from .stubdata.export import example_export_response
+
+
+class TestSandbox(unittest.TestCase):
+    """
+    Test the sandbox environment
+    """
+
+    def test_search_query(self):
+        """
+        Test you should receive stub Solr data when using SearchQuery
+        """
+        sq = SearchQuery(q="star", rows=28)
+
+        b1 = [a.bibcode for a in sq]
+
+        resp = json.loads(example_solr_response)
+        b2 = [i['bibcode'] for i in resp['response']['docs']]
+
+        self.assertSequenceEqual(b1, b2)
+
+    def test_article_get_field(self):
+        """
+        Test you should receive stub data when accessing cached properties
+        """
+        sq = SearchQuery(q='fake bibcode', fl=['bibcode', 'id'])
+        b = [a for a in sq]
+
+        citation_count = b[0].citation_count
+        author = b[0].author
+        volume = int(b[0].volume)
+
+        self.assertEqual(citation_count, 0)
+        self.assertEqual(author[0], u'Sudilovsky, Oscar')
+        self.assertEqual(volume, 174)
+
+        metrics = b[0].metrics
+        self.assertEqual(metrics, json.loads(example_metrics_response))
+
+        export = b[0].bibtex
+        self.assertEqual(export, json.loads(example_export_response)['export'])
+
+    def test_metrics_query(self):
+        """
+        Test you should receive stub metrics data when using MetricsQuery
+        """
+        mq = MetricsQuery(['bibcode'])
+        metrics = mq.execute()
+
+        self.assertEqual(metrics, json.loads(example_metrics_response))
+
+    def test_export_query(self):
+        """
+        Test you should receive stub export data when using ExportQuery
+        """
+        eq = ExportQuery(bibcodes=['bibcode'], format='bibtex')
+        export = eq.execute()
+
+        self.assertEqual(export, json.loads(example_export_response)['export'])
+
+if __name__ == '__main__':
+    unittest.main(verbosity=2)


### PR DESCRIPTION
ADS sandbox environment as suggested in #47 by @andycasey.

Basic search
```python
>>> import ads.sandbox as ads
>>> q = ads.SearchQuery(q='fake query')
>>> q.execute()
>>> q.articles[0].author
['Sudilovsky, Oscar', 'Pestana, Angel', 'Hinderaker, Paul H.', 'Pitot, Henry C.']
>>> q.progress
'28/28'
```

Cached properties
```python
>>> q.articles[0].read_count
0.0
>>> assert q.articles[0].volume == '174'
>>> q.response.get_ratelimits()
{'reset': None, 'remaining': None, 'limit': None}
```

metrics cached property
```python
>>> metrics = q.articles[0].metrics
>>> metrics['basic stats']['total number of reads']
111
```

export cached property
```python
>>> e = b[0].bibtex
>>> print(e)
@ARTICLE{2013A&A...552A.143S,
   author = {{Sudilovsky}, V. and {Greiner}, J. and {Rau}, A. and {Salvato}, M. and 
        {Savaglio}, S. and {Vergani}, S.~D. and {Schady}, P. and {Elliott}, J. and 
        {Kr{\"u}hler}, T. and {Kann}, D.~A. and {Klose}, S. and {Rossi}, A. and 
        {Filgas}, R. and {Schmidl}, S.},
    title = "{Clustering of galaxies around gamma-ray burst sight-lines}",
  journal = {\aap},
archivePrefix = "arXiv",
   eprint = {1302.6362},
 keywords = {gamma-ray burst: general, galaxies: statistics},
     year = 2013,
    month = apr,
   volume = 552,
      eid = {A143},
    pages = {A143},
      doi = {10.1051/0004-6361/201321247},
   adsurl = {http://adsabs.harvard.edu/abs/2013A%26A...552A.143S},
  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
}
```

metrics
```python
>>> m = ads.MetricsQuery(bibcodes=['fake'])
>>> metrics = m.execute()                                                                                                        
>>> len(metrics)
```

.... and export
```python
>>> e = ads.ExportQuery(bibcodes=['does not exist'], format='bibtex')                                                                            
>>> export = e.execute()
>>> print(export)
@ARTICLE{2013A&A...552A.143S,
   author = {{Sudilovsky}, V. and {Greiner}, J. and {Rau}, A. and {Salvato}, M. and 
        {Savaglio}, S. and {Vergani}, S.~D. and {Schady}, P. and {Elliott}, J. and 
        {Kr{\"u}hler}, T. and {Kann}, D.~A. and {Klose}, S. and {Rossi}, A. and 
        {Filgas}, R. and {Schmidl}, S.},
    title = "{Clustering of galaxies around gamma-ray burst sight-lines}",
  journal = {\aap},
archivePrefix = "arXiv",
   eprint = {1302.6362},
 keywords = {gamma-ray burst: general, galaxies: statistics},
     year = 2013,
    month = apr,
   volume = 552,
      eid = {A143},
    pages = {A143},
      doi = {10.1051/0004-6361/201321247},
   adsurl = {http://adsabs.harvard.edu/abs/2013A%26A...552A.143S},
  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
}
```