### PR TITLE
Response JSON decoder and UTF detection

### DIFF
--- a/ads/base.py
+++ b/ads/base.py
@@ -85,15 +85,15 @@ class APIResponse(object):
         return RateLimits.getRateLimits(cls.__name__).to_dict()
 
     @classmethod
-    def load_http_response(cls, HTTPResponse):
+    def load_http_response(cls, http_response):
         """
-        This method should return an instansitated class and set its response
+        This method should return an instantiated class and set its response
         to the requests.Response object.
         """
-        if not HTTPResponse.ok:
-            raise APIResponseError(HTTPResponse.text)
-        c = cls(HTTPResponse.text)
-        c.response = HTTPResponse
+        if not http_response.ok:
+            raise APIResponseError(http_response.text)
+        c = cls(http_response)
+        c.response = http_response
 
         RateLimits.getRateLimits(cls.__name__).set(c.response.headers)
 
@@ -146,7 +146,6 @@ class BaseQuery(object):
         """
         if self._session is None:
             self._session = requests.session()
-            self._session.hooks = dict(response=self.__session_hook_response)
             self._session.headers.update(
                 {
                     "Authorization": "Bearer {}".format(self.token),
@@ -155,13 +154,6 @@ class BaseQuery(object):
                 }
             )
         return self._session
-
-    def __session_hook_response(self, r, *args, **kwargs):
-        """
-        :type r: requests.Response
-        """
-        if r.encoding is None:
-            r.encoding = ads.config.default_response_encoding
 
     def __call__(self):
         return self.execute()

--- a/ads/base.py
+++ b/ads/base.py
@@ -160,7 +160,8 @@ class BaseQuery(object):
         """
         :type r: requests.Response
         """
-        r.encoding = ads.config.default_response_encoding
+        if r.encoding is None:
+            r.encoding = ads.config.default_response_encoding
 
     def __call__(self):
         return self.execute()

--- a/ads/base.py
+++ b/ads/base.py
@@ -146,6 +146,7 @@ class BaseQuery(object):
         """
         if self._session is None:
             self._session = requests.session()
+            self._session.hooks = dict(response=self.__session_hook_response)
             self._session.headers.update(
                 {
                     "Authorization": "Bearer {}".format(self.token),
@@ -154,6 +155,12 @@ class BaseQuery(object):
                 }
             )
         return self._session
+
+    def __session_hook_response(self, r, *args, **kwargs):
+        """
+        :type r: requests.Response
+        """
+        r.encoding = ads.config.default_response_encoding
 
     def __call__(self):
         return self.execute()

--- a/ads/config.py
+++ b/ads/config.py
@@ -19,4 +19,3 @@ TOKEN_FILES = list(map(os.path.expanduser,
 ))
 TOKEN_ENVIRON_VARS = ["ADS_API_TOKEN", "ADS_DEV_KEY"]
 token = None  # for setting in-situ
-default_response_encoding = 'utf-8'

--- a/ads/config.py
+++ b/ads/config.py
@@ -19,3 +19,4 @@ TOKEN_FILES = list(map(os.path.expanduser,
 ))
 TOKEN_ENVIRON_VARS = ["ADS_API_TOKEN", "ADS_DEV_KEY"]
 token = None  # for setting in-situ
+default_response_encoding = 'utf-8'

--- a/ads/export.py
+++ b/ads/export.py
@@ -14,9 +14,9 @@ class ExportResponse(APIResponse):
     """
     Data structure that represents a response from the ads metrics service
     """
-    def __init__(self, raw):
-        self._raw = raw
-        self.result = json.loads(raw)['export']
+    def __init__(self, http_response):
+        self._raw = http_response.text
+        self.result = http_response.json()['export']
 
     def __str__(self):
         if six.PY3:

--- a/ads/metrics.py
+++ b/ads/metrics.py
@@ -13,9 +13,9 @@ class MetricsResponse(APIResponse):
     """
     Data structure that represents a response from the ads metrics service
     """
-    def __init__(self, raw):
-        self._raw = raw
-        self.metrics = json.loads(raw)
+    def __init__(self, http_response):
+        self._raw = http_response.text
+        self.metrics = http_response.json()
 
     def __str__(self):
         if six.PY3:

--- a/ads/search.py
+++ b/ads/search.py
@@ -244,14 +244,14 @@ class SolrResponse(APIResponse):
     Base class for storing a solr response
     """
 
-    def __init__(self, raw):
+    def __init__(self, http_response):
         """
         De-serialize a json string representing a solr response
-        :param raw: complete json response from solr
-        :type raw: basestring
+        :param http_response: complete json response from solr
+        :type http_response: request.response
         """
-        self._raw = raw
-        self.json = json.loads(raw)
+        self._raw = http_response.text
+        self.json = http_response.json()
         self._articles = None
         try:
             self.responseHeader = self.json['responseHeader']

--- a/ads/tests/mocks.py
+++ b/ads/tests/mocks.py
@@ -27,6 +27,17 @@ class HTTPrettyMock(object):
         HTTPretty.disable()
 
 
+class MockResponse(object):
+    """
+    mock for a simple response with a given body
+    """
+    def __init__(self, body):
+        self.text = body
+
+    def json(self):
+        return json.loads(self.text)
+
+
 class MockApiResponse(HTTPrettyMock):
     """
     context manager than mocks an static adsws-api response

--- a/ads/tests/test_base.py
+++ b/ads/tests/test_base.py
@@ -104,7 +104,7 @@ class TestRateLimits(unittest.TestCase):
 
     def setUp(self):
         class FakeResponse(APIResponse):
-            def __init__(self, raw):
+            def __init__(self, http_response):
                 pass
 
         self.FakeResponse = FakeResponse

--- a/ads/tests/test_export.py
+++ b/ads/tests/test_export.py
@@ -5,7 +5,7 @@ import unittest
 import six
 import os
 
-from .mocks import MockExportResponse
+from .mocks import MockResponse, MockExportResponse
 
 from ads.export import ExportQuery, ExportResponse
 from ads.config import EXPORT_URL
@@ -46,7 +46,7 @@ class TestExportResponse(unittest.TestCase):
         an initialized ExportResponse should have an attribute result
         that is a string, and an attribute _raw that is a string
         """
-        er = ExportResponse('{"export": "[data]"}')
+        er = ExportResponse(MockResponse('{"export": "[data]"}'))
         self.assertEqual(er.result, "[data]")  # No parsing!
         self.assertIsInstance(er._raw, six.string_types)
 

--- a/ads/tests/test_metrics.py
+++ b/ads/tests/test_metrics.py
@@ -4,7 +4,7 @@ Tests for MetricsQuery
 import unittest
 import six
 
-from .mocks import MockMetricsResponse
+from .mocks import MockResponse, MockMetricsResponse
 
 from ads.metrics import MetricsQuery, MetricsResponse
 from ads.config import METRICS_URL
@@ -45,7 +45,7 @@ class TestMetricsResponse(unittest.TestCase):
         an initialized MetricsResponse should have an attribute metrics
         that is a dictionary, and an attribute _raw that is a string
         """
-        mr = MetricsResponse('{"valid":"json"}')
+        mr = MetricsResponse(MockResponse('{"valid":"json"}'))
         self.assertIsInstance(mr.metrics, dict)
         self.assertIsInstance(mr._raw, six.string_types)
 

--- a/ads/tests/test_search.py
+++ b/ads/tests/test_search.py
@@ -8,7 +8,7 @@ from mock import patch
 import six
 import warnings
 
-from ads.tests.mocks import MockSolrResponse
+from ads.tests.mocks import MockResponse, MockSolrResponse
 
 from ads.search import SearchQuery, SolrResponse, APIResponse, Article, query
 from ads.exceptions import APIResponseError, SolrResponseParseError
@@ -226,7 +226,7 @@ class TestSolrResponse(unittest.TestCase):
         and that if critical data are missing then raise SolrResponseParseError
         """
 
-        sr = SolrResponse(self.response.text)
+        sr = SolrResponse(self.response)
         self.assertIn('responseHeader', sr.json)
         self.assertIn('response', sr.json)
         self.assertEqual(sr.numFound, 28)
@@ -237,14 +237,14 @@ class TestSolrResponse(unittest.TestCase):
             'this_is_now_malformed_data',
         )
         with self.assertRaises(SolrResponseParseError):
-            SolrResponse(malformed_text)
+            SolrResponse(MockResponse(malformed_text))
 
     def test_articles(self):
         """
         the article attribute should be read-only, and set the first time
         it is called
         """
-        sr = SolrResponse(self.response.text)
+        sr = SolrResponse(self.response)
         self.assertIsNone(sr._articles)
         self.assertEqual(len(sr.articles), 28)
         self.assertEqual(sr._articles, sr.articles)
@@ -273,7 +273,7 @@ class TestSolrResponse(unittest.TestCase):
         articles should have their properties set to None for each key in fl,
         if the response has no data.
         """
-        sr = SolrResponse(self.response.text)
+        sr = SolrResponse(self.response)
         sr.docs = [{"id": 1}]
         sr.fl = ['id', 'bibstem']
         self.assertEqual(sr.articles[0].id, 1)


### PR DESCRIPTION
In some cases the returned data was garbled, and it turns out that the response object of the requests package had to guess the encoding via the chardet library, as the content-type returned by the server didn't include a character set. In a particular case, the guessed ("apparent") encoding was TIS-620 instead of UTF-8.

As the data returned is UTF-8 encoded JSON, this is easily fixed by hinting the response on the encoding to use. I added a response hook for the session to set the encoding to a configured value, if no explicit encoding was given by the server and before the text content of the response is used, defaulting to UTF-8. The previous guessing behaviour can be restored by setting the configuration value to `None`.