### PR TITLE
Feature: cached_property warning

### DIFF
--- a/ads/search.py
+++ b/ads/search.py
@@ -5,7 +5,6 @@ Interface to the adsws search api.
 import warnings
 import six
 import math
-from werkzeug.utils import cached_property as _cached_property
 import json
 
 from .config import SEARCH_URL
@@ -13,25 +12,7 @@ from .exceptions import SolrResponseParseError, APIResponseError
 from .base import BaseQuery, APIResponse
 from .metrics import MetricsQuery
 from .export import ExportQuery
-
-
-class cached_property(_cached_property):
-    """
-    Wrap cached property to print relevant warnings
-    """
-    def __init__(self, func, name=None, doc=None):
-        super(cached_property, self).__init__(func, name, doc)
-
-    def __get__(self, obj, type=None):
-        # One time warning that the user is using lazy loading
-        warnings.warn(
-            "You are lazy loading attributes via '{}', and so are "
-            "making multiple calls to the API. This will impact your overall "
-            "rate limits."
-            .format(self.func.__name__),
-            UserWarning,
-        )
-        return super(cached_property, self).__get__(obj, type)
+from .utils import cached_property
 
 
 class Article(object):

--- a/ads/search.py
+++ b/ads/search.py
@@ -5,7 +5,7 @@ Interface to the adsws search api.
 import warnings
 import six
 import math
-from werkzeug.utils import cached_property
+from werkzeug.utils import cached_property as _cached_property
 import json
 
 from .config import SEARCH_URL
@@ -13,6 +13,25 @@ from .exceptions import SolrResponseParseError, APIResponseError
 from .base import BaseQuery, APIResponse
 from .metrics import MetricsQuery
 from .export import ExportQuery
+
+
+class cached_property(_cached_property):
+    """
+    Wrap cached property to print relevant warnings
+    """
+    def __init__(self, func, name=None, doc=None):
+        super(cached_property, self).__init__(func, name, doc)
+
+    def __get__(self, obj, type=None):
+        # One time warning that the user is using lazy loading
+        warnings.warn(
+            "You are lazy loading attributes via '{}', and so are "
+            "making multiple calls to the API. This will impact your overall "
+            "rate limits."
+            .format(self.func.__name__),
+            UserWarning,
+        )
+        return super(cached_property, self).__get__(obj, type)
 
 
 class Article(object):

--- a/ads/tests/test_utils.py
+++ b/ads/tests/test_utils.py
@@ -1,0 +1,34 @@
+"""
+Tests for utility functions
+"""
+import warnings
+import unittest
+
+from ads.utils import cached_property
+
+
+class TestUtils(unittest.TestCase):
+    """
+    Test utility functions
+    """
+
+    def test_cached_property(self):
+        """
+        Test that the cached property raises a warning when __get__ is accessed
+        """
+        class DummyClass(object):
+            @cached_property
+            def lazy_attribute(self):
+                return 1
+
+        dc = DummyClass()
+        with warnings.catch_warnings(record=True) as w:
+            dc.lazy_attribute
+            self.assertEqual(len(w), 1)
+
+            # Should only print once unless the filter is changed
+            dc.lazy_attribute
+            self.assertEqual(len(w), 1)
+
+if __name__ == '__main__':
+    unittest.main(verbosity=2)

--- a/ads/utils.py
+++ b/ads/utils.py
@@ -1,0 +1,25 @@
+"""
+Utilities and helpers
+"""
+
+import warnings
+from werkzeug.utils import cached_property as _cached_property
+
+
+class cached_property(_cached_property):
+    """
+    Wrap cached property to print relevant warnings
+    """
+    def __init__(self, func, name=None, doc=None):
+        super(cached_property, self).__init__(func, name, doc)
+
+    def __get__(self, obj, type=None):
+        # One time warning that the user is using lazy loading
+        warnings.warn(
+            "You are lazy loading attributes via '{}', and so are "
+            "making multiple calls to the API. This will impact your overall "
+            "rate limits."
+            .format(self.func.__name__),
+            UserWarning,
+        )
+        return super(cached_property, self).__get__(obj, type)


### PR DESCRIPTION
@vsudilov, @andycasey brought this up in #47, and suggested just giving the user a warning.

I originally just put a `warnings.warn()` inside `_get_field`, but this would mean putting it in other places, `citation`, `reference`, `metric`, and `export`. For now I overrode cached_property to include a warning, if you have a neater/preferred method, let me know.

The behaviour is as follows:

```python
>>> import ads
>>> q = ads.SearchQuery(q='star')
>>> q.execute()
>>> q.articles[0].citation_count
ads/ads/search.py:31: UserWarning: You are lazy loading attributes via 'citation_count', and so are making multiple calls to the API. This will impact your overall rate limits.
  UserWarning,
1
```

It only gives the warning once per session for the cached property, ie., further `.citation_count` calls won't give a warning, but `.metrics` would.
