### PR TITLE
Additional article properties

### DIFF
--- a/ads/search.py
+++ b/ads/search.py
@@ -25,11 +25,6 @@ class Article(object):
     # services; this is why it is currently impossible for it to live in
     # base.py, which is the most logical place for it.
 
-    # Field processors to i.e. decode fields that contain JSON strings.
-    _processors = {
-        'links_data': lambda v: map(json.loads, v)
-    }
-
     def __init__(self, **kwargs):
         """
         :param kwargs: Set object attributes from kwargs
@@ -37,10 +32,7 @@ class Article(object):
 
         self._raw = kwargs
         for key, value in six.iteritems(kwargs):
-            if value is not None and key in Article._processors:
-                setattr(self, key, Article._processors[key](value))
-            else:
-                setattr(self, key, value)
+            setattr(self, key, value)
 
     def __str__(self):
         if six.PY3:
@@ -122,7 +114,6 @@ class Article(object):
         """
         Queries the api for a single field for the record by `id`.
         This method should only be called indirectly by cached properties.
-        Returned field values are automatically processed.
         :param field: name of the record field to load
         """
         if not hasattr(self, "id") or self.id is None:
@@ -132,9 +123,6 @@ class Article(object):
         # return None instead of hitting _get_field again.
         if field not in sq._raw:
             return None
-        # Fields are processed in the constructor. As the separately fetched field
-        # is provided via a temporarily created Article instance, the field has
-        # already been processed.
         value = sq.__getattribute__(field)
         self._raw[field] = value
         return value
@@ -160,10 +148,6 @@ class Article(object):
         return self._get_field('author')
 
     @cached_property
-    def author_norm(self):
-        return self._get_field('author_norm')
-
-    @cached_property
     def citation_count(self):
         return self._get_field('citation_count')
 
@@ -180,18 +164,6 @@ class Article(object):
         return self._get_field('bibgroup')
 
     @cached_property
-    def body(self):
-        return self._get_field('body')
-
-    @cached_property
-    def cite_read_boost(self):
-        return self._get_field('cite_read_boost')
-
-    @cached_property
-    def classic_factor(self):
-        return self._get_field('classic_factor')
-
-    @cached_property
     def copyright(self):
         return self._get_field('copyright')
 
@@ -204,10 +176,6 @@ class Article(object):
         return self._get_field('database')
 
     @cached_property
-    def date(self):
-        return self._get_field('date')
-
-    @cached_property
     def doctype(self):
         return self._get_field('doctype')
 
@@ -216,24 +184,12 @@ class Article(object):
         return self._get_field('doi')
 
     @cached_property
-    def eid(self):
-        return self._get_field('eid')
-
-    @cached_property
-    def email(self):
-        return self._get_field('email')
-
-    @cached_property
     def identifier(self):
         return self._get_field('identifier')
 
     @cached_property
     def indexstamp(self):
         return self._get_field('indexstamp')
-
-    @cached_property
-    def first_author(self):
-        return self._get_field('first_author')
 
     @cached_property
     def first_author_norm(self):
@@ -248,22 +204,6 @@ class Article(object):
         return self._get_field('keyword')
 
     @cached_property
-    def keyword_facet(self):
-        return self._get_field('keyword_facet')
-
-    @cached_property
-    def keyword_norm(self):
-        return self._get_field('keyword_norm')
-
-    @cached_property
-    def keyword_schema(self):
-        return self._get_field('keyword_schema')
-
-    @cached_property
-    def links_data(self):
-        return self._get_field('links_data')
-
-    @cached_property
     def page(self):
         return self._get_field('page')
 
@@ -276,24 +216,12 @@ class Article(object):
         return self._get_field('pub')
 
     @cached_property
-    def pub_raw(self):
-        return self._get_field('pub_raw')
-
-    @cached_property
     def pubdate(self):
         return self._get_field('pubdate')
 
     @cached_property
     def read_count(self):
         return self._get_field('read_count')
-
-    @cached_property
-    def reader(self):
-        return self._get_field('reader')
-
-    @cached_property
-    def recid(self):
-        return self._get_field('recid')
 
     @cached_property
     def reference(self):
@@ -310,18 +238,6 @@ class Article(object):
             fl=['id', 'bibcode']
         )
         return [a.bibcode for a in q]
-
-    @cached_property
-    def simbad_object_facet_hier(self):
-        return self._get_field('simbad_object_facet_hier')
-
-    @cached_property
-    def simbid(self):
-        return self._get_field('simbid')
-
-    @cached_property
-    def simbtype(self):
-        return self._get_field('simbtype')
 
     @cached_property
     def title(self):

--- a/ads/search.py
+++ b/ads/search.py
@@ -132,12 +132,20 @@ class Article(object):
         return self._get_field('abstract')
 
     @cached_property
+    def ack(self):
+        return self._get_field('ack')
+
+    @cached_property
     def aff(self):
         return self._get_field('aff')
 
     @cached_property
     def alternate_bibcode(self):
         return self._get_field('alternate_bibcode')
+
+    @cached_property
+    def alternate_title(self):
+        return self._get_field('alternate_title')
 
     @cached_property
     def arxiv_class(self):
@@ -204,6 +212,10 @@ class Article(object):
         return self._get_field('keyword')
 
     @cached_property
+    def lang(self):
+        return self._get_field('lang')
+
+    @cached_property
     def page(self):
         return self._get_field('page')
 
@@ -242,6 +254,10 @@ class Article(object):
     @cached_property
     def title(self):
         return self._get_field('title')
+
+    @cached_property
+    def vizier(self):
+        return self._get_field('vizier')
 
     @cached_property
     def volume(self):

--- a/ads/search.py
+++ b/ads/search.py
@@ -24,6 +24,12 @@ class Article(object):
     # Article.metrics, this class has dependencies on search.py and other core
     # services; this is why it is currently impossible for it to live in
     # base.py, which is the most logical place for it.
+
+    # Field processors to i.e. decode fields that contain JSON strings.
+    _processors = {
+        'links_data': lambda v: map(json.loads, v)
+    }
+
     def __init__(self, **kwargs):
         """
         :param kwargs: Set object attributes from kwargs
@@ -31,7 +37,10 @@ class Article(object):
 
         self._raw = kwargs
         for key, value in six.iteritems(kwargs):
-            setattr(self, key, value)
+            if value is not None and key in Article._processors:
+                setattr(self, key, Article._processors[key](value))
+            else:
+                setattr(self, key, value)
 
     def __str__(self):
         if six.PY3:
@@ -113,6 +122,7 @@ class Article(object):
         """
         Queries the api for a single field for the record by `id`.
         This method should only be called indirectly by cached properties.
+        Returned field values are automatically processed.
         :param field: name of the record field to load
         """
         if not hasattr(self, "id") or self.id is None:
@@ -122,6 +132,9 @@ class Article(object):
         # return None instead of hitting _get_field again.
         if field not in sq._raw:
             return None
+        # Fields are processed in the constructor. As the separately fetched field
+        # is provided via a temporarily created Article instance, the field has
+        # already been processed.
         value = sq.__getattribute__(field)
         self._raw[field] = value
         return value
@@ -135,12 +148,28 @@ class Article(object):
         return self._get_field('aff')
 
     @cached_property
+    def alternate_bibcode(self):
+        return self._get_field('alternate_bibcode')
+
+    @cached_property
+    def arxiv_class(self):
+        return self._get_field('arxiv_class')
+
+    @cached_property
     def author(self):
         return self._get_field('author')
 
     @cached_property
+    def author_norm(self):
+        return self._get_field('author_norm')
+
+    @cached_property
     def citation_count(self):
         return self._get_field('citation_count')
+
+    @cached_property
+    def bibcode(self):
+        return self._get_field('bibcode')
 
     @cached_property
     def bibstem(self):
@@ -151,12 +180,32 @@ class Article(object):
         return self._get_field('bibgroup')
 
     @cached_property
+    def body(self):
+        return self._get_field('body')
+
+    @cached_property
+    def cite_read_boost(self):
+        return self._get_field('cite_read_boost')
+
+    @cached_property
+    def classic_factor(self):
+        return self._get_field('classic_factor')
+
+    @cached_property
+    def copyright(self):
+        return self._get_field('copyright')
+
+    @cached_property
     def data(self):
         return self._get_field('data')
 
     @cached_property
     def database(self):
         return self._get_field('database')
+
+    @cached_property
+    def date(self):
+        return self._get_field('date')
 
     @cached_property
     def doctype(self):
@@ -167,8 +216,24 @@ class Article(object):
         return self._get_field('doi')
 
     @cached_property
+    def eid(self):
+        return self._get_field('eid')
+
+    @cached_property
+    def email(self):
+        return self._get_field('email')
+
+    @cached_property
     def identifier(self):
         return self._get_field('identifier')
+
+    @cached_property
+    def indexstamp(self):
+        return self._get_field('indexstamp')
+
+    @cached_property
+    def first_author(self):
+        return self._get_field('first_author')
 
     @cached_property
     def first_author_norm(self):
@@ -183,6 +248,22 @@ class Article(object):
         return self._get_field('keyword')
 
     @cached_property
+    def keyword_facet(self):
+        return self._get_field('keyword_facet')
+
+    @cached_property
+    def keyword_norm(self):
+        return self._get_field('keyword_norm')
+
+    @cached_property
+    def keyword_schema(self):
+        return self._get_field('keyword_schema')
+
+    @cached_property
+    def links_data(self):
+        return self._get_field('links_data')
+
+    @cached_property
     def page(self):
         return self._get_field('page')
 
@@ -195,12 +276,24 @@ class Article(object):
         return self._get_field('pub')
 
     @cached_property
+    def pub_raw(self):
+        return self._get_field('pub_raw')
+
+    @cached_property
     def pubdate(self):
         return self._get_field('pubdate')
 
     @cached_property
     def read_count(self):
         return self._get_field('read_count')
+
+    @cached_property
+    def reader(self):
+        return self._get_field('reader')
+
+    @cached_property
+    def recid(self):
+        return self._get_field('recid')
 
     @cached_property
     def reference(self):
@@ -217,6 +310,18 @@ class Article(object):
             fl=['id', 'bibcode']
         )
         return [a.bibcode for a in q]
+
+    @cached_property
+    def simbad_object_facet_hier(self):
+        return self._get_field('simbad_object_facet_hier')
+
+    @cached_property
+    def simbid(self):
+        return self._get_field('simbid')
+
+    @cached_property
+    def simbtype(self):
+        return self._get_field('simbtype')
 
     @cached_property
     def title(self):

--- a/ads/search.py
+++ b/ads/search.py
@@ -147,8 +147,24 @@ class Article(object):
         return self._get_field('bibstem')
 
     @cached_property
+    def bibgroup(self):
+        return self._get_field('bibgroup')
+
+    @cached_property
+    def data(self):
+        return self._get_field('data')
+
+    @cached_property
     def database(self):
         return self._get_field('database')
+
+    @cached_property
+    def doctype(self):
+        return self._get_field('doctype')
+
+    @cached_property
+    def doi(self):
+        return self._get_field('doi')
 
     @cached_property
     def identifier(self):

--- a/ads/tests/test_search.py
+++ b/ads/tests/test_search.py
@@ -54,7 +54,8 @@ class TestArticle(unittest.TestCase):
         self.assertNotEqual(Article(bibcode="Not the same"), self.article)
         self.assertEqual(Article(bibcode="2013A&A...552A.143S"), self.article)
         with self.assertRaises(TypeError):
-            Article() == self.article
+            # Explicitly set bibcode to None to avoid invoking the getter.
+            Article(bibcode=None) == self.article
 
     def test_init(self):
         """


### PR DESCRIPTION
Several new on-demand getters for fields that I encountered in articles. I guess there are many more to be added. A different approach could maybe use `__getattr__` instead of explicitly defining each field.

One of the newly supported fields, `link_data`, is a list of strings that contain JSON. I added a value processor to automatically parse those accordingly during the Article constructor (and hence implicitly for the getter).
There are other fields for which additional parsing may be useful, notably all date-related fields that are RFC 3339 encoded and could easily be processed using `dateutil.parse`.