### PR TITLE
Hotfix: issue#61

### DIFF
--- a/ads/search.py
+++ b/ads/search.py
@@ -164,10 +164,6 @@ class Article(object):
         return self._get_field('bibcode')
 
     @cached_property
-    def bibstem(self):
-        return self._get_field('bibstem')
-
-    @cached_property
     def bibgroup(self):
         return self._get_field('bibgroup')
 
@@ -210,10 +206,6 @@ class Article(object):
     @cached_property
     def keyword(self):
         return self._get_field('keyword')
-
-    @cached_property
-    def lang(self):
-        return self._get_field('lang')
 
     @cached_property
     def page(self):


### PR DESCRIPTION
Removed bibstem as a property, and lang, as both are not stored in the search engine of the ADS, and so do not return anything when requested in the fl parameter.