### PR TITLE
Hotfix: issue #68 - lazy loading msg

### DIFF
--- a/ads/tests/test_utils.py
+++ b/ads/tests/test_utils.py
@@ -1,34 +1,78 @@
 """
 Tests for utility functions
 """
-import warnings
+import mock
 import unittest
 
 from ads.utils import cached_property
 
 
+class DummyClass(object):
+    @cached_property
+    def lazy_attribute(self):
+        return 1
+
+
 class TestUtils(unittest.TestCase):
     """
     Test utility functions
+
+    Note: mock.patch has been used to mock warnings.warn rather than using the
+    context manager to catch any warnings called. This is because there is no
+    easy way to reset them, see:
+
+    http://bugs.python.org/issue21724
+
     """
 
-    def test_cached_property(self):
+    def setUp(self):
+        self.dc = DummyClass()
+  
+    @mock.patch('ads.utils.warnings')
+    def test_cached_property(self, m_warn):
         """
         Test that the cached property raises a warning when __get__ is accessed
         """
-        class DummyClass(object):
-            @cached_property
-            def lazy_attribute(self):
-                return 1
 
-        dc = DummyClass()
-        with warnings.catch_warnings(record=True) as w:
-            dc.lazy_attribute
-            self.assertEqual(len(w), 1)
+        m_warn.warn.return_value = None
 
-            # Should only print once unless the filter is changed
-            dc.lazy_attribute
-            self.assertEqual(len(w), 1)
+        # Lazy load should trigger message
+        self.dc.lazy_attribute
+        self.assertEqual(
+            len(m_warn.warn.mock_calls),
+            1
+        )
+
+        # Should only print once unless the filter is changed
+        self.dc.lazy_attribute
+        self.assertEqual(
+            len(m_warn.warn.mock_calls),
+            1
+        )
+        m_warn.warn.assert_called_once()
+
+    @mock.patch('ads.utils.warnings')
+    def test_cached_property_already_loaded(self, m_warn):
+        """
+        Test there is no warning message when someone accesses a lazy loading
+        attribute that has already been accessed.
+        """
+
+        # Pretend we have this value in our object already
+        setattr(self.dc, 'lazy_attribute', 1)
+
+        # Lazy load test
+        self.assertEqual(
+            len(m_warn.warn.mock_calls),
+            0
+        )
+
+        self.dc.lazy_attribute
+
+        self.assertEqual(
+            len(m_warn.warn.mock_calls),
+            0
+        )
 
 if __name__ == '__main__':
     unittest.main(verbosity=2)

--- a/ads/tests/test_utils.py
+++ b/ads/tests/test_utils.py
@@ -10,6 +10,7 @@ from ads.utils import cached_property
 class DummyClass(object):
     @cached_property
     def lazy_attribute(self):
+        print('here')
         return 1
 
 
@@ -55,7 +56,7 @@ class TestUtils(unittest.TestCase):
     def test_cached_property_already_loaded(self, m_warn):
         """
         Test there is no warning message when someone accesses a lazy loading
-        attribute that has already been accessed.
+        attribute that has already been loaded on instantiation.
         """
 
         # Pretend we have this value in our object already

--- a/ads/tests/test_utils.py
+++ b/ads/tests/test_utils.py
@@ -50,7 +50,6 @@ class TestUtils(unittest.TestCase):
             len(m_warn.warn.mock_calls),
             1
         )
-        m_warn.warn.assert_called_once()
 
     @mock.patch('ads.utils.warnings')
     def test_cached_property_already_loaded(self, m_warn):

--- a/ads/tests/test_utils.py
+++ b/ads/tests/test_utils.py
@@ -1,78 +1,47 @@
 """
 Tests for utility functions
 """
-import mock
+import warnings
 import unittest
 
 from ads.utils import cached_property
 
 
-class DummyClass(object):
-    @cached_property
-    def lazy_attribute(self):
-        print('here')
-        return 1
-
-
 class TestUtils(unittest.TestCase):
     """
     Test utility functions
-
-    Note: mock.patch has been used to mock warnings.warn rather than using the
-    context manager to catch any warnings called. This is because there is no
-    easy way to reset them, see:
-
-    http://bugs.python.org/issue21724
-
     """
 
-    def setUp(self):
-        self.dc = DummyClass()
-  
-    @mock.patch('ads.utils.warnings')
-    def test_cached_property(self, m_warn):
+    def test_cached_property(self):
         """
         Test that the cached property raises a warning when __get__ is accessed
         """
+        class DummyClass(object):
+            @cached_property
+            def lazy_attribute(self):
+                return 42
 
-        m_warn.warn.return_value = None
+        dc = DummyClass()
 
-        # Lazy load should trigger message
-        self.dc.lazy_attribute
-        self.assertEqual(
-            len(m_warn.warn.mock_calls),
-            1
-        )
+        with warnings.catch_warnings(record=True) as w:
+            dc.lazy_attribute
+            self.assertEqual(
+                len(w),
+                1
+            )
 
-        # Should only print once unless the filter is changed
-        self.dc.lazy_attribute
-        self.assertEqual(
-            len(m_warn.warn.mock_calls),
-            1
-        )
+            # Should only print once unless the filter is changed
+            dc.lazy_attribute
+            self.assertEqual(
+                len(w),
+                1
+            )
 
-    @mock.patch('ads.utils.warnings')
-    def test_cached_property_already_loaded(self, m_warn):
-        """
-        Test there is no warning message when someone accesses a lazy loading
-        attribute that has already been loaded on instantiation.
-        """
-
-        # Pretend we have this value in our object already
-        setattr(self.dc, 'lazy_attribute', 1)
-
-        # Lazy load test
-        self.assertEqual(
-            len(m_warn.warn.mock_calls),
-            0
-        )
-
-        self.dc.lazy_attribute
-
-        self.assertEqual(
-            len(m_warn.warn.mock_calls),
-            0
-        )
+        # no warning if attr is explicitly set
+        with warnings.catch_warnings(record=True) as w:
+            dc.lazy_attribute = 'foo'
+            dc.lazy_attribute
+            self.assertEqual(len(w), 0)
 
 if __name__ == '__main__':
     unittest.main(verbosity=2)

--- a/ads/utils.py
+++ b/ads/utils.py
@@ -4,6 +4,7 @@ Utilities and helpers
 
 import warnings
 from werkzeug.utils import cached_property as _cached_property
+from werkzeug._internal import _missing
 
 
 class cached_property(_cached_property):
@@ -14,12 +15,21 @@ class cached_property(_cached_property):
         super(cached_property, self).__init__(func, name, doc)
 
     def __get__(self, obj, type=None):
-        # One time warning that the user is using lazy loading
-        warnings.warn(
-            "You are lazy loading attributes via '{}', and so are "
-            "making multiple calls to the API. This will impact your overall "
-            "rate limits."
-            .format(self.func.__name__),
-            UserWarning,
-        )
-        return super(cached_property, self).__get__(obj, type)
+        # Essentially copying to insert a message....: 
+        # https://github.com/pallets/werkzeug/blob/master/werkzeug/utils.py
+
+        if obj is None:
+            return self
+        value = obj.__dict__.get(self.__name__, _missing)
+        if value is _missing:
+            # One time warning that the user is using lazy loading
+            warnings.warn(
+                "You are lazy loading attributes via '{}', and so are "
+                "making multiple calls to the API. This will impact your overall "
+                "rate limits."
+                .format(self.func.__name__),
+                UserWarning,
+            )
+            value = self.func(obj)
+            obj.__dict__[self.__name__] = value
+        return value


### PR DESCRIPTION
Message was being printed all the time for any cached property due to missing logic.

There is probably a better way. I'm essentially just copy/pasting the majority of the decorator from werkzeug just to insert a message, which feels kind of ugly.