### PR TITLE
SearchQuery: Support solr cursors for pagination; references #70

### DIFF
--- a/ads/tests/mocks.py
+++ b/ads/tests/mocks.py
@@ -67,8 +67,6 @@ class MockApiResponse(HTTPrettyMock):
         )
 
 
-
-
 class MockSolrResponse(HTTPrettyMock):
     """
     context manager that mocks a Solr response
@@ -111,6 +109,10 @@ class MockSolrResponse(HTTPrettyMock):
                 for doc in resp['response']['docs']
             ]
             resp['responseHeader']['params']['fl'] = fl
+
+            # Mimic cursor behavior if specified
+            if request.querystring.get('cursorMark'):
+                resp['nextCursorMark'] = "AoIH///3RmWrhAAjMTY0"
 
             return 200, headers, json.dumps(resp)
 

--- a/ads/tests/test_search.py
+++ b/ads/tests/test_search.py
@@ -156,7 +156,7 @@ class TestSearchQuery(unittest.TestCase):
         data row by row and ensure that the data return as expected
         """
 
-        sq = SearchQuery(q="unittest", rows=1, max_pages=20)
+        sq = SearchQuery(q="unittest", rows=1, max_pages=20, start=0)
         with MockSolrResponse(sq.HTTP_ENDPOINT):
             self.assertEqual(sq._query['start'], 0)
             self.assertEqual(next(sq).bibcode, '1971Sci...174..142S')
@@ -180,7 +180,7 @@ class TestSearchQuery(unittest.TestCase):
         with MockSolrResponse(sq.HTTP_ENDPOINT):
             self.assertEqual(len(list(sq)), 3)
 
-        # setting a sort should use cursorMark for pagination
+        # Default should use cursorMark
         sq = SearchQuery(q="unittest", sort="date")
         with MockSolrResponse(sq.HTTP_ENDPOINT):
             self.assertEqual(next(sq).bibcode, '1971Sci...174..142S')
@@ -222,6 +222,19 @@ class TestSearchQuery(unittest.TestCase):
         self.assertEqual(sq.query['cursorMark'], '*')
         self.assertNotIn('start', sq.query)
         self.assertEqual(sq.query['sort'], 'date desc,id desc')
+
+        sq = SearchQuery(q="star", start=0)
+        self.assertEqual(sq.query['start'], 0)
+        self.assertEqual(sq.query['sort'], "score desc")
+
+        sq = SearchQuery(q="star", start=0, sort="date")
+        self.assertEqual(sq.query['start'], 0)
+        self.assertEqual(sq.query['sort'], "date desc")
+
+        sq = SearchQuery({"q": "star"})
+        self.assertEqual(sq.query['cursorMark'], "*")
+        self.assertEqual(sq.query['sort'], "score desc,id desc")
+        self.assertNotIn('start', sq.query)
 
         with six.assertRaisesRegex(self, AssertionError, ".+mutually exclusive.+"):
             SearchQuery(q="start", start=0, cursorMark="*")
@@ -300,7 +313,6 @@ class TestSolrResponse(unittest.TestCase):
         self.assertEqual(sr.articles[0].id, 1)
         self.assertEqual(sr.articles[0].bibstem, None)
         self.assertEqual(patched.call_count, 0)
-
 
 
 class Testquery(unittest.TestCase):

--- a/ads/tests/test_search.py
+++ b/ads/tests/test_search.py
@@ -225,6 +225,7 @@ class TestSearchQuery(unittest.TestCase):
 
         sq = SearchQuery(q="star", start=0)
         self.assertEqual(sq.query['start'], 0)
+        self.assertNotIn('cursorMark', sq.query)
         self.assertEqual(sq.query['sort'], "score desc")
 
         sq = SearchQuery(q="star", start=0, sort="date")


### PR DESCRIPTION
use cursorMark (https://cwiki.apache.org/confluence/display/solr/Pagination+of+Results) as the default pagination parameter