### PR TITLE
allow unicode encoded authors in the queries

### DIFF
--- a/ads/search.py
+++ b/ads/search.py
@@ -401,8 +401,8 @@ class SearchQuery(BaseQuery):
 
             # Format and add kwarg (key, value) pairs to q
             if kwargs:
-                _ = ['{}:"{}"'.format(k, v) for k, v in six.iteritems(kwargs)]
-                self._query['q'] = '{} {}'.format(self._query['q'], ' '.join(_))
+                _ = [u'{}:"{}"'.format(k, v) for k, v in six.iteritems(kwargs)]
+                self._query['q'] = u'{} {}'.format(self._query['q'], ' '.join(_))
 
         assert self._query.get('rows') > 0, "rows must be greater than 0"
         assert self._query.get('q'), "q must not be empty"

--- a/ads/tests/test_search.py
+++ b/ads/tests/test_search.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """
 Tests for the search interface
 """
@@ -236,6 +237,10 @@ class TestSearchQuery(unittest.TestCase):
         self.assertEqual(sq.query['cursorMark'], "*")
         self.assertEqual(sq.query['sort'], "score desc,id desc")
         self.assertNotIn('start', sq.query)
+
+        # test unicode
+        sq = SearchQuery(author=u'é')
+        self.assertIn(u'é', sq.query['q'])
 
         with six.assertRaisesRegex(self, AssertionError, ".+mutually exclusive.+"):
             SearchQuery(q="start", start=0, cursorMark="*")


### PR DESCRIPTION
Hi, 

By default pyads doesn't like unicode encoded authors in the queries. See:
```
In [2]: import ads

In [3]: q1=ads.SearchQuery(author=u'Benoit-Lévy')
---------------------------------------------------------------------------
UnicodeEncodeError                        Traceback (most recent call last)
<ipython-input-3-60065533adfc> in <module>()
----> 1 q1=ads.SearchQuery(author=u'Benoit-Lévy')

/home/koposov/my_usr/pylib/lib/python2.7/site-packages/ads/search.pyc in __init__(self, query_dict, q, fq, fl, sort, start, rows, max_pages, token, **kwargs)
    342             # Format and add kwarg (key, value) pairs to q
    343             if kwargs:
--> 344                 _ = ['{}:"{}"'.format(k, v) for k, v in six.iteritems(kwargs)]
    345                 self._query['q'] = '{} {}'.format(self._query['q'], ' '.join(_))
    346 

UnicodeEncodeError: 'ascii' codec can't encode character u'\xe9' in position 8: ordinal not in range(128)

```

With the fix, it works fine 
```
In [1]: import ads

In [2]: q1=ads.SearchQuery(author=u'Benoit-Lévy')

In [3]: q1.next().author
Out[3]: [u'Manzotti, Alessandro', u'Hu, Wayne', u'Benoit-L\xe9vy, Aur\xe9lien']
```
I didn't try to ensure that all of the ads.query machinery can deal with unicode though, because I didn't need it.