### PR TITLE
SearchQuery: explicitly remove "bibtex", "metrics" from fl; closes #73

### DIFF
--- a/ads/search.py
+++ b/ads/search.py
@@ -399,6 +399,12 @@ class SearchQuery(BaseQuery):
             else:
                 self._query["fl"] = ["id"] + self._query["fl"]
 
+            # remove bibtex and metrics as a safeguard against
+            # https://github.com/andycasey/ads/issues/73
+            for field in ["bibtex", "metrics"]:
+                if field in self._query["fl"]:
+                    self.query["fl"].remove(field)
+
             # Format and add kwarg (key, value) pairs to q
             if kwargs:
                 _ = [u'{}:"{}"'.format(k, v) for k, v in six.iteritems(kwargs)]

--- a/ads/tests/test_search.py
+++ b/ads/tests/test_search.py
@@ -245,6 +245,10 @@ class TestSearchQuery(unittest.TestCase):
         with six.assertRaisesRegex(self, AssertionError, ".+mutually exclusive.+"):
             SearchQuery(q="start", start=0, cursorMark="*")
 
+        # test that bibtex/metrics is excluded from sq.query['fl']
+        sq = SearchQuery(q="star", fl=["f1", "bibtex", "f2", "metrics", "f3"])
+        self.assertEqual(sq.query['fl'], ["id", "f1", "f2", "f3"])
+
 
 class TestSolrResponse(unittest.TestCase):
     """


### PR DESCRIPTION
Let's remove bibtex, metrics and any other fields exposed on `Article` but not fetched directly from the solr doc so as to prevent potential confusion if a user includes one of these fields in their `fl` parameter. See #73 for more context.