### PR TITLE
Allow more recent versions of httpretty

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 six
 requests
-httpretty==0.8.10
+httpretty>=0.8.10
 werkzeug
 mock


### PR DESCRIPTION
With up-to-date versions of everything, the (3½ year-old) version of httpretty in requirements.txt fails to install.  Up-to-date versions of httpretty seem to work with `ads`, so I see no reason for requiring such an old version.