### PR TITLE
add additional export formats

### DIFF
--- a/ads/export.py
+++ b/ads/export.py
@@ -33,8 +33,8 @@ class ExportQuery(BaseQuery):
     """
 
     HTTP_ENDPOINT = EXPORT_URL
-    FORMATS = ['bibtex', 'endnote', 'aastex',
-               'ris', 'icarus', 'mnras', 'soph']
+    FORMATS = ['bibtex', 'bibtexabs', 'ads','endnote', 'aastex',
+               'ris', 'icarus', 'mnras', 'soph', 'votable']
 
     def __init__(self, bibcodes, format="bibtex"):
         """


### PR DESCRIPTION
added three new export formats mentioned [here](https://github.com/adsabs/adsabs-dev-api/blob/master/Export_API.ipynb). I plan to use ads.ExportQuery(..,format='bibtexabs') to get the abstract text in the LaTex form; the text from ads.SearchsQuery(..,fl=[..,'abstract']) seems to be in HTML.
