### PR TITLE
Fix bug in cached_property

### DIFF
--- a/ads/utils.py
+++ b/ads/utils.py
@@ -30,10 +30,6 @@ class cached_property(_cached_property):
                 .format(self.__name__),
                 UserWarning,
             )
-            try:
-                value = self.func(obj)
-            except AttributeError:
-                # for python versions at least >= 3.9.6
-                value = self.fget(obj)            
+            value = self.fget(obj)
             obj.__dict__[self.__name__] = value
         return value

--- a/ads/utils.py
+++ b/ads/utils.py
@@ -27,9 +27,9 @@ class cached_property(_cached_property):
                 "You are lazy loading attributes via '{}', and so are "
                 "making multiple calls to the API. This will impact your overall "
                 "rate limits."
-                .format(self.func.__name__),
+                .format(self.__name__),
                 UserWarning,
             )
-            value = self.func(obj)
+            value = self.fget(obj)
             obj.__dict__[self.__name__] = value
         return value

--- a/ads/utils.py
+++ b/ads/utils.py
@@ -30,6 +30,10 @@ class cached_property(_cached_property):
                 .format(self.__name__),
                 UserWarning,
             )
-            value = self.fget(obj)
+            try:
+                value = self.func(obj)
+            except AttributeError:
+                # for python versions at least >= 3.9.6
+                value = self.fget(obj)            
             obj.__dict__[self.__name__] = value
         return value


### PR DESCRIPTION
I wanted to use `ads` to get the BibTeX code for a given set of papers, basically running[^1]:

```python
import ads
papers = list(ads.query("^Casey, Andrew R."))
print(papers[1].bibtex)
```

However, that resulted in the following error:

```
Traceback (most recent call last):
  File "/Users/timothy/Desktop/ads/test.py", line 6, in <module>
    print(papers[1].bibtex)
  File "/Users/timothy/Desktop/ads/ads/utils.py", line 31, in __get__
    .format(self.func.__name__),
AttributeError: 'cached_property' object has no attribute 'func'
```

I started digging a bit into it, and I think the problem is the following: `ads.utils.cached_property` is supposed to be a very thin wrapper around `werkzeug.utils.cached_property`. However, the latter one [was updated a while ago](https://github.com/pallets/werkzeug/commit/28343b#diff-b9d6906a0da8b5a9877b17ac5ea491161a660ce7e513921738d3e284bd9e9c96L85), and in particularly the constructor—on which the `ads` version relies—was changed (i.e., the `func` property was removed).

I have now adjusted the `ads` version of `cached_property` so that it matched the one in `werkzeug` again, which should fix the error above 🙂 

[FYI, starting with Python 3.8, the built-in `functools` library comes with [its own implementation](https://docs.python.org/3.8/library/functools.html#functools.cached_property) of `cached_property`. Depending on which Python versions you want to support, that might be a way to drop the `werkzeug` dependency?]

[^1]: I have since come to realize that this is _not_ the best approach, and that I should probably use ```ExportQuery()``` directly instead?