### PR TITLE
changed syntax in cached_property for python >= 3.9.6

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 *__pycache__*
 *.egg-info
 .coverage
+build
 
 docs/_build
 venv/

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ python:
 - 2.7
 - 2.7_with_system_site_packages
 - 3.4
+- 3.9.6
+- 3.10.2
 install:
 - pip install -r requirements.txt
 - pip install coverage coveralls

--- a/ads/utils.py
+++ b/ads/utils.py
@@ -3,19 +3,21 @@ Utilities and helpers
 """
 
 import warnings
-from werkzeug.utils import cached_property as _cached_property
+
 from werkzeug._internal import _missing
+from werkzeug.utils import cached_property as _cached_property
 
 
 class cached_property(_cached_property):
     """
     Wrap cached property to print relevant warnings
     """
+
     def __init__(self, func, name=None, doc=None):
         super(cached_property, self).__init__(func, name, doc)
 
     def __get__(self, obj, type=None):
-        # Essentially copying to insert a message....: 
+        # Essentially copying to insert a message....:
         # https://github.com/pallets/werkzeug/blob/master/werkzeug/utils.py
 
         if obj is None:
@@ -23,13 +25,22 @@ class cached_property(_cached_property):
         value = obj.__dict__.get(self.__name__, _missing)
         if value is _missing:
             # One time warning that the user is using lazy loading
+            try:
+                name = self.func.__name__
+            except AttributeError:
+                # for python versions at least >= 3.9.6
+                name = self.fget.__name__
             warnings.warn(
                 "You are lazy loading attributes via '{}', and so are "
                 "making multiple calls to the API. This will impact your overall "
-                "rate limits."
-                .format(self.func.__name__),
+                "rate limits.".format(name),
                 UserWarning,
             )
-            value = self.func(obj)
+
+            try:
+                value = self.func(obj)
+            except AttributeError:
+                # for python versions at least >= 3.9.6
+                value = self.fget(obj)
             obj.__dict__[self.__name__] = value
         return value


### PR DESCRIPTION
The syntax in cached_property changed at the version change from 1.0.x to 2.0.x in [werkzeug](https://github.com/pallets/werkzeug) package.

I, therefore, introduced a try-except block to use the newer attribute `fget` instead of `func` if an AttributeError occurs. 


For running:
````bash
python -m unittest discover > ~/testresult.txt

s./Users/user/repositories/ads/ads/base.py:135: RuntimeWarning: No token found
  warnings.warn("No token found", RuntimeWarning)
........../Users/user/repositories/ads/ads/utils.py:33: UserWarning: You are lazy loading attributes via 'citation_count', and so are making multiple calls to the API. This will impact your overall rate limits.
  warnings.warn(
/Users/user/repositories/ads/ads/utils.py:33: UserWarning: You are lazy loading attributes via 'author', and so are making multiple calls to the API. This will impact your overall rate limits.
  warnings.warn(
/Users/user/repositories/ads/ads/utils.py:33: UserWarning: You are lazy loading attributes via 'volume', and so are making multiple calls to the API. This will impact your overall rate limits.
  warnings.warn(
/Users/user/repositories/ads/ads/utils.py:33: UserWarning: You are lazy loading attributes via 'metrics', and so are making multiple calls to the API. This will impact your overall rate limits.
  warnings.warn(
/Users/user/repositories/ads/ads/search.py:288: UserWarning: metrics should be queried with ads.MetricsQuery(); You willhit API ratelimits very quickly otherwise.
  warnings.warn("metrics should be queried with ads.MetricsQuery(); You will"
/Users/user/repositories/ads/ads/utils.py:33: UserWarning: You are lazy loading attributes via 'bibtex', and so are making multiple calls to the API. This will impact your overall rate limits.
  warnings.warn(
/Users/user/repositories/ads/ads/search.py:295: UserWarning: bibtex should be queried with ads.ExportQuery(); You will hit API ratelimits very quickly otherwise.
  warnings.warn("bibtex should be queried with ads.ExportQuery(); You will "
..../Users/user/repositories/ads/ads/utils.py:33: UserWarning: You are lazy loading attributes via 'aff', and so are making multiple calls to the API. This will impact your overall rate limits.
  warnings.warn(
../Users/user/repositories/ads/ads/utils.py:33: UserWarning: You are lazy loading attributes via 'pubdate', and so are making multiple calls to the API. This will impact your overall rate limits.
  warnings.warn(
/Users/user/repositories/ads/ads/utils.py:33: UserWarning: You are lazy loading attributes via 'read_count', and so are making multiple calls to the API. This will impact your overall rate limits.
  warnings.warn(
/Users/user/repositories/ads/ads/utils.py:33: UserWarning: You are lazy loading attributes via 'issue', and so are making multiple calls to the API. This will impact your overall rate limits.
  warnings.warn(
.../Users/user/repositories/ads/ads/utils.py:33: UserWarning: You are lazy loading attributes via 'first_author', and so are making multiple calls to the API. This will impact your overall rate limits.
  warnings.warn(
/Users/user/repositories/ads/ads/utils.py:33: UserWarning: You are lazy loading attributes via 'author', and so are making multiple calls to the API. This will impact your overall rate limits.
  warnings.warn(
/Users/user/repositories/ads/ads/utils.py:33: UserWarning: You are lazy loading attributes via 'year', and so are making multiple calls to the API. This will impact your overall rate limits.
  warnings.warn(
.........../Users/user/repositories/ads/ads/search.py:567: DeprecationWarning: ads.query will be deprectated. Use ads.SearchQuery in the future
  warnings.warn(
..
----------------------------------------------------------------------
Ran 34 tests in 0.176s

OK (skipped=1)
````
I do not know why the test does not find my token in ~/.ads/dev_key, but this works for regular use.