### PR TITLE
Enhancement: Add optional arguments to MetricsQuery

### DIFF
--- a/ads/metrics.py
+++ b/ads/metrics.py
@@ -33,16 +33,34 @@ class MetricsQuery(BaseQuery):
 
     HTTP_ENDPOINT = METRICS_URL
 
-    def __init__(self, bibcodes):
-        """
-        :param bibcodes: Bibcodes to send to in the metrics query
-        :type bibcodes: list or string
-        """
-        self.response = None  # current MetricsResponse object
-        if isinstance(bibcodes, six.string_types):
-            bibcodes = [bibcodes]
-        self.bibcodes = bibcodes
-        self.json_payload = json.dumps({"bibcodes": bibcodes})
+    def __init__(self, bibcodes, types=None, histograms=None):
+    """
+    :param bibcodes: Bibcodes to send to in the metrics query
+    :type bibcodes: list or string
+    :param types: Optional keyword to specify the metrics type to retrieve.
+    :type types: list or string
+    :param histograms: Optional keyword can be set to specify the histograms to
+        return, if `histograms` is specified under types.
+    :type histograms: list or string
+    """
+    self.response = None  # current MetricsResponse object
+    if isinstance(bibcodes, six.string_types):
+        bibcodes = [bibcodes]
+    self.bibcodes = bibcodes
+    
+    # Handle optionals
+    optionals = {}
+    for opt in ["types", "histograms"]:
+        par = locals()[opt]
+        if isinstance(par, six.string_types):
+            par = [par]
+        setattr(self, opt, par)
+    if types is not None:
+        optionals["types"] = self.types
+        if "histograms" in types and histograms is not None:
+            optionals["histograms"] = self.histograms
+    
+    self.json_payload = json.dumps({"bibcodes": bibcodes, **optionals})
 
     def execute(self):
         """


### PR DESCRIPTION
Suggestion to enhance `ads.MetricsQuery` by adding missing implementation for `type` and `histograms` arguments provided by the ADS API (as documented [here](https://github.com/adsabs/adsabs-dev-api/blob/master/API_documentation_Python/Metrics_API_Python.ipynb)).

For my use case, evaluating citation metrics (histograms) of O(10^3) bibcodes, being able to limit the query to just include histograms drastically improved the API response both in therms of speed and error rate.

Hope this helps :)